### PR TITLE
カテゴリー追加機能と検索機能の実装

### DIFF
--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -5,3 +5,4 @@ $light_blue: #38AEF0;
 $light_gray: #999;
 $black: #434a54;
 $alert_orange: #F35500;
+$brown-color: #2C1E0C;

--- a/app/assets/stylesheets/topics/_index.scss
+++ b/app/assets/stylesheets/topics/_index.scss
@@ -1,7 +1,7 @@
 .header {
   width: 100%;
   position: fixed;
-  background-color: $light_blue;
+  background-color: $brown-color;
   opacity: 0.85;
   color: white;
   z-index: 1;
@@ -23,6 +23,16 @@
       line-height: 100px;
       width: 80%;
       justify-content: flex-end;
+      align-items: center;
+      .search {
+        line-height: 40px;
+        .search-input {
+          width: 200px;
+        }
+        .search-btn {
+          width: 70px;
+        }
+      }
       .name {
         padding-top: 1px;
         font-size: calc(7px + 1vw);
@@ -45,6 +55,11 @@
 
 .topics-index-wrapper {
   padding-top: 150px;
+  .contents__blank {
+    margin-top: 100px;
+    font-size: 20px;
+    text-align: center;
+  }
   .content {
     border-bottom: 1px dotted;
     &__title {

--- a/app/assets/stylesheets/topics/_new.scss
+++ b/app/assets/stylesheets/topics/_new.scss
@@ -1,4 +1,9 @@
+.new-content {
+  h1 {
+    text-align: center;
+  }
+}
+
 .topics-new-contents {
   padding-top: 150px;
-  text-align: center;
 }

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,11 +1,12 @@
 class TopicsController < ApplicationController
   def index
-    @topics = Topic.all
+    @topics = Topic.all.order(id: "desc")
   end
 
   def new
     @topic = Topic.new
     @topic.responses.new
+    @topic.categories.new
   end
 
   def create
@@ -22,9 +23,14 @@ class TopicsController < ApplicationController
     @response = Response.new
   end
 
+  def search
+    @topics = Topic.search(params[:keyword])
+    render action: :index
+  end
+
   private
 
   def topic_params
-    params.require(:topic).permit(:title, responses_attributes: [:content, :user_id]).merge(user_id: current_user.id)
+    params.require(:topic).permit(:title, responses_attributes: [:content, :user_id], categories_attributes: [:name]).merge(user_id: current_user.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,2 +1,4 @@
 class Category < ApplicationRecord
+  has_many :topics_categories
+  has_many :topics, through: :topics_categories
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -4,6 +4,12 @@ class Topic < ApplicationRecord
   accepts_nested_attributes_for :responses, allow_destroy: true
   has_many :topics_categories
   has_many :categories, through: :topics_categories
+  accepts_nested_attributes_for :categories, allow_destroy: true
 
   validates :title, presence: true
+
+  def self.search(search)
+    # return .all unless search
+    Topic.where('title LIKE(?)', "%#{search}%") + Response.where('content LIKE(?)', "%#{search}%")
+  end
 end

--- a/app/models/topics_category.rb
+++ b/app/models/topics_category.rb
@@ -1,2 +1,4 @@
 class TopicsCategory < ApplicationRecord
+  belongs_to :topic
+  belongs_to :category
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,16 +16,18 @@
           %h1.app-name
             %a{ href: "/" } 5.5ch
           %ul.header-contents
-            %li.header-contents__content
-              = link_to "検索", class: 'btn'
+            %li.header-contents__content.search
+              = form_with(url: search_topics_path, local: true, method: :get, class: "search-form") do |form|
+                = form.text_field :keyword, placeholder: "スレッドおよびレスを検索", class: "search-input"
+                = form.submit "検索", class: "search-btn"
             -if user_signed_in?
               %li.header-contents__content.name
                 = current_user.nickname
-              %li.header-contents__content
+              %li.header-contents__content.log_out
                 = link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'btn'
             -else
-              %li.header-contents__content
+              %li.header-contents__content.sign_up
                 = link_to "新規登録", new_user_registration_path, class: 'btn'
-              %li.header-contents__content
+              %li.header-contents__content.log_in
                 = link_to "ログイン", new_user_session_path, class: 'btn'
     = yield

--- a/app/views/topics/index.html.haml
+++ b/app/views/topics/index.html.haml
@@ -3,9 +3,26 @@
     .new-topic-btn
       = link_to 'スレッドを新規作成する', new_topic_path, class: "btn btn-primary"
     .contents
-      - @topics.each do |topic|
-        %ul.content
-          %li.content__title
-            = link_to topic.title, topic_path(topic)
-          %li.content__content
-            =topic.responses[0].content
+      .contents__blank
+        = "検索に該当するスレッドがありません" if @topics.blank?
+      - @topics.each do |content|
+        - if content.class == Topic
+          %ul.content
+            %li.content__title
+              = link_to content.title, topic_path(content)
+            %li.content__category
+              = "カテゴリー:"
+              - content.categories.each do |category|
+                = "【#{category.name}】"
+            %li.content__content
+              =content.responses[0].content
+        - else content.class == Response
+          %ul.content
+            %li.content__title
+              = link_to content.topic.title, topic_path(content.topic)
+            %li.content__category
+              = "カテゴリー:"
+              - content.topic.categories.each do |category|
+                = "【#{category.name}】"
+            %li.content__content
+              =content.topic.responses[0].content

--- a/app/views/topics/new.html.haml
+++ b/app/views/topics/new.html.haml
@@ -4,11 +4,21 @@
       %h1 新しく作成するスレッドの情報を記入してください
       = form_with(model: @topic, local: true, class: "new-topic-form") do |form|
         = form.label :title, "スレッドタイトル", class: "label"
+        <br>
         = form.text_field :title, clas: "form-input title"
+        = form.fields_for :categories do |category|
+          .new-topic-form__category
+            .new-topic-form__category__input
+              = category.label :name, "カテゴリー", class: "label"
+              <br>
+              = category.text_field :name, name: "topic[categories_attributes][0][name]", class: "form-input name"
+              = category.text_field :name, name: "topic[categories_attributes][1][name]",class: "form-input name"
+              = category.text_field :name, name: "topic[categories_attributes][2][name]",class: "form-input name"
         = form.fields_for :responses do |response|
           .new-topic-form__response
             .new-topic-form__response__input
               = response.label :content, "1レス目の投稿", class: "label"
+              <br>
               = response.text_area :content, class: "form-input content"
               = response.hidden_field :user_id, value: current_user.id
         .new-topic-form__submit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,11 @@ Rails.application.routes.draw do
     registrations: 'users/registrations'
   }
 
-  resources :topics
+  resources :topics do
+    collection do
+      get 'search'
+    end
+  end
   resources :responses
+  resources :categories
 end


### PR DESCRIPTION
# What
- スレッド作成時にカテゴリーを追加する機能を実装した
  - カテゴリー入力欄に入力する
  - スレッド一覧画面で入力されたカテゴリーを表示する
- 検索バーを作成し、スレッドのタイトルおよびレスの内容でキーワード検索できるようにした
  - searchアクションを追加した
  - モデルにTopicのtitleとResponseのcontentでキーワード検索するメソッドを追加した
  - クエリ発行により得られたデータは@topicsに格納し、
そのモデルがTopicかResponseかでビュー表示の処理の仕方を変えた

# Why
- カテゴリーで分類されていることで何の記事かわかるようにするため
- スレッドのタイトルだけでなく、レスの内容についても検索できるようにするため