### PR TITLE
カテゴリー付与機能のアップデート

### DIFF
--- a/app/assets/stylesheets/_flash.scss
+++ b/app/assets/stylesheets/_flash.scss
@@ -1,0 +1,13 @@
+.notification {
+  .notice {
+    background-color: $light_blue;
+    color: $white;
+    text-align: center;
+  }
+
+  .alert {
+    background-color: $alert_orange;
+    color: $white;
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "./colors";
 @import "./reset";
+@import "flash";
 @import "./users";
 @import "./topics/index";
 @import "./topics/new";

--- a/app/assets/stylesheets/topics/_index.scss
+++ b/app/assets/stylesheets/topics/_index.scss
@@ -49,6 +49,10 @@
   }
 }
 
+.notice-bar {
+  padding-top: 100px;
+}
+
 .new-topic-btn {
   text-align: center;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,15 @@
 class ApplicationController < ActionController::Base
-  # before_action :authenticate_user!
-  # before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+  end
+
+  def ensure_login
+    unless user_signed_in?
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -1,4 +1,5 @@
 class ResponsesController < ApplicationController
+  before_action :ensure_login, only: [:create]
 
   def create
     @response = Response.create(response_params)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,4 +1,7 @@
 class TopicsController < ApplicationController
+  before_action :ensure_login, only: [:new, :create]
+
+
   def index
     @topics = Topic.all.order(id: "desc")
   end
@@ -12,8 +15,13 @@ class TopicsController < ApplicationController
   def create
     @topic = Topic.new(topic_params)
     if @topic.save
+      category_ids = params[:topic][:categories].map{|i| i.to_i}
+      category_ids.each do |id|
+        @topics_categories = TopicsCategory.create(topic_id: @topic.id, category_id: id)
+      end
       redirect_to action: :index
     else
+      flash.now[:alert] = '必須事項を入力してください。'
       render action: :new
     end
   end
@@ -31,6 +39,6 @@ class TopicsController < ApplicationController
   private
 
   def topic_params
-    params.require(:topic).permit(:title, responses_attributes: [:content, :user_id], categories_attributes: [:name]).merge(user_id: current_user.id)
+    params.require(:topic).permit(:title, responses_attributes: [:content, :user_id]).merge(user_id: current_user.id)
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -4,12 +4,10 @@ class Topic < ApplicationRecord
   accepts_nested_attributes_for :responses, allow_destroy: true
   has_many :topics_categories
   has_many :categories, through: :topics_categories
-  accepts_nested_attributes_for :categories, allow_destroy: true
 
   validates :title, presence: true
 
   def self.search(search)
-    # return .all unless search
     Topic.where('title LIKE(?)', "%#{search}%") + Response.where('content LIKE(?)', "%#{search}%")
   end
 end

--- a/app/views/layouts/_notifications.html.haml
+++ b/app/views/layouts/_notifications.html.haml
@@ -1,0 +1,4 @@
+.notification
+  - flash.each do |message_type, message|
+    %div{:class => "alert alert-#{message_type}"}
+      = message

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,4 +30,6 @@
                 = link_to "新規登録", new_user_registration_path, class: 'btn'
               %li.header-contents__content.log_in
                 = link_to "ログイン", new_user_session_path, class: 'btn'
+      .notice-bar
+        = render 'layouts/notifications'
     = yield

--- a/app/views/topics/new.html.haml
+++ b/app/views/topics/new.html.haml
@@ -3,7 +3,7 @@
     .new-content
       %h1 新しく作成するスレッドの情報を記入してください
       = form_with(model: @topic, local: true, class: "new-topic-form") do |form|
-        = form.label :title, "スレッドタイトル", class: "label"
+        = form.label :title, "スレッドタイトル(*必須)", class: "label"
         <br>
         = form.text_field :title, clas: "form-input title"
         = form.fields_for :categories do |category|
@@ -11,13 +11,13 @@
             .new-topic-form__category__input
               = category.label :name, "カテゴリー", class: "label"
               <br>
-              = category.text_field :name, name: "topic[categories_attributes][0][name]", class: "form-input name"
-              = category.text_field :name, name: "topic[categories_attributes][1][name]",class: "form-input name"
-              = category.text_field :name, name: "topic[categories_attributes][2][name]",class: "form-input name"
+              - Category.all.each_with_index do |category, index|
+                = check_box_tag 'topic[categories][]', category.id, false
+                = category.name
         = form.fields_for :responses do |response|
           .new-topic-form__response
             .new-topic-form__response__input
-              = response.label :content, "1レス目の投稿", class: "label"
+              = response.label :content, "1レス目の投稿(*必須)", class: "label"
               <br>
               = response.text_area :content, class: "form-input content"
               = response.hidden_field :user_id, value: current_user.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,11 +7,10 @@ Rails.application.routes.draw do
     registrations: 'users/registrations'
   }
 
-  resources :topics do
+  resources :topics, only: [:index, :new, :create, :show] do
     collection do
       get 'search'
     end
   end
-  resources :responses
-  resources :categories
+  resources :responses, only: [:create]
 end


### PR DESCRIPTION
# What
- スレッドを作る際のカテゴリー付与をチェックボックスによる選択式にした
- スレッド作成の際に中間テーブルに紐づける情報を登録するようにした
- スレッド作成、レス作成の前にユーザーログインしているかどうかで処理を分けるように実装した
- 必須事項がない場合にはフラッシュメッセージを表記するよう設定した

# Why
- 個々人がそれぞれカテゴリーを記載するよりもチェックボックス式の方が後々分類しやすいと判断した
- ユーザーログインしていないと新規作成できないようにするため